### PR TITLE
Add GitHub issue templates for bugs and features

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: 🐞 Bug Report
+about: Report a bug to help us improve
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+A clear and concise description of what the bug is.
+
+## To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
+## Screenshots
+If applicable, add screenshots to help explain your problem.
+
+## Environment (please complete the following information):
+ - OS: [e.g. Windows 10]
+ - Browser [e.g. Chrome, Edge, Firefox]
+ - Version [e.g. v1.0.0]
+
+## Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: 🚀 Feature Request
+about: Suggest a new feature or improvement
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+---
+
+## Is your feature request related to a problem? Please describe.
+A clear and concise description of what the problem is. For example: “I’m always frustrated when ...”.
+
+## Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+## Alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional context
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This PR adds two GitHub issue templates to help standardize reporting in the repository:

1. **Bug Report** (`bug_report.md`): A template for users to report bugs, including sections for description, steps to reproduce, expected behavior, screenshots, environment, and additional context.

2. **Feature Request** (`feature_request.md`): A template for suggesting new features or improvements, including sections for description, motivation, and additional context.

These templates will improve issue quality and make it easier for maintainers to track and resolve contributions.
